### PR TITLE
Force color output for readability

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,9 @@ jobs:
   deployment-test:
     name: Deployment Test
     runs-on: ubuntu-latest
+    env:
+      PY_COLORS: '1'
+      ANSIBLE_FORCE_COLOR: '1'
     strategy:
       matrix:
         deployment: [webapp, strimzi_kafka, queue_processor]

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,6 +1,5 @@
 [defaults]
 inventory = inventory.ini
-force_color = True
 
 [diff]
 always = true


### PR DESCRIPTION
Ensures output from running ansible-playbook is in colour

Easier to check if something is OK, Changed, or an Error